### PR TITLE
Added parsing support for the const type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,16 @@ test::
 
 test::
 	@ echo
+	$(HERD_REGRESSION_TEST) \
+		-herd-path $(HERD) \
+		-libdir-path ./herd/libdir \
+		-litmus-dir ./herd/tests/instructions/C \
+		-conf ./herd/tests/instructions/C/c.cfg \
+		$(REGRESSION_TEST_MODE)
+	@ echo "herd7 AArch64 C instructions tests: OK"
+
+test::
+	@ echo
 	$(HERD_DIYCROSS_REGRESSION_TEST) \
 		-herd-path $(HERD) \
 		-diycross-path $(DIYCROSS) \

--- a/herd/tests/instructions/C/C01.litmus
+++ b/herd/tests/instructions/C/C01.litmus
@@ -1,0 +1,10 @@
+C C01
+
+{ x = 1 }
+
+P0 (const int* x) {
+  int r0 = *x;
+}
+
+
+forall (0:r0=1)

--- a/herd/tests/instructions/C/C01.litmus.expected
+++ b/herd/tests/instructions/C/C01.litmus.expected
@@ -1,0 +1,10 @@
+Test C01 Required
+States 1
+0:r0=0x1;
+Ok
+Witnesses
+Positive: 1 Negative: 0
+Condition forall (0:r0=0x1)
+Observation C01 Always 1 0
+Hash=f26e77b9ef2528a6e6c9757a77f150a1
+

--- a/herd/tests/instructions/C/C02.litmus
+++ b/herd/tests/instructions/C/C02.litmus
@@ -1,0 +1,10 @@
+C C02
+
+{}
+
+P0 (const int* y,volatile int* x) {
+  int r0 = *x;
+  *y = 1;
+}
+
+forall (0:r0=1 /\ y=1)

--- a/herd/tests/instructions/C/C02.litmus.expected
+++ b/herd/tests/instructions/C/C02.litmus.expected
@@ -1,0 +1,10 @@
+Test C02 Required
+States 1
+0:r0=0x0; y=0x1;
+No
+Witnesses
+Positive: 0 Negative: 1
+Condition forall (0:r0=0x1 /\ y=0x1)
+Observation C02 Never 0 1
+Hash=d92b65c8b850301b8f1b811599b2f905
+

--- a/herd/tests/instructions/C/c.cfg
+++ b/herd/tests/instructions/C/c.cfg
@@ -1,0 +1,2 @@
+hexa true
+model herd/libdir/rc11.cat

--- a/lib/CLexer.mll
+++ b/lib/CLexer.mll
@@ -24,6 +24,7 @@ module LU = LexUtils.Make(O)
 (* Compiled efficiently by the next version of ocaml *)
 let tr_name s = match s with
 | "volatile" -> VOLATILE
+| "const" -> CONST
 | "_Atomic" -> ATOMIC
 | "char" -> CHAR
 | "int" -> INT

--- a/lib/CParser.mly
+++ b/lib/CParser.mly
@@ -34,7 +34,7 @@ open MemOrderOrAnnot
 %token LPAR RPAR COMMA LBRACE RBRACE STAR
 %token ATOMIC CHAR INT LONG VOID
 %token MUTEX
-%token VOLATILE
+%token VOLATILE CONST
 %token STRUCT
 
 /* For shallow parsing */
@@ -99,8 +99,10 @@ void:
 typ:
 | typ_ptr { $1 }
 | typ VOLATILE { Volatile $1 }
+| typ CONST { CType.Const $1 }
 | ATOMIC base { Atomic $2 }
 | VOLATILE base0 { Volatile $2 }
+| CONST base0 { Const $2 }
 | base { $1 }
 
 base0:
@@ -163,10 +165,10 @@ expr:
 | expr1 { $1 }
 
 expr0:
-| CONSTANT { Const(Constant.Concrete $1) }
-| CONSTVAR { Const(mk_sym $1) }
-| IDENTIFIER { LoadReg $1 }
-| STAR IDENTIFIER { LoadMem (LoadReg $2,AN []) }
+| CONSTANT { CBase.Const(Constant.Concrete $1) }
+| CONSTVAR { CBase.Const(mk_sym $1) }
+| IDENTIFIER { CBase.LoadReg $1 }
+| STAR IDENTIFIER { CBase.LoadMem (CBase.LoadReg $2,AN []) }
 | LPAR expr RPAR { $2 }
 
 expr1:

--- a/lib/CType.mli
+++ b/lib/CType.mli
@@ -21,6 +21,7 @@ type base = string
 type t =
   | Base of base
   | Volatile of t
+  | Const of t
   | Atomic of t
   | Pointer of t
 (** limited arrays *)
@@ -45,6 +46,7 @@ val is_array : t -> bool
 val is_atomic : t -> bool
 val strip_atomic : t -> t
 val strip_volatile : t -> t
+val strip_const : t -> t
 val strip_attributes : t -> t
 
 val is_ptr_to_atomic : t -> bool

--- a/litmus/CCompile_litmus.ml
+++ b/litmus/CCompile_litmus.ml
@@ -68,7 +68,8 @@ module Make
     | _ -> None
 
     let add_param {CAst.param_ty; param_name=g} env =
-      let ty = CType.strip_volatile param_ty in
+      let ty = CType.strip_const param_ty in
+      let ty = CType.strip_volatile ty in
       try
         let oty = StringMap.find g env in
 (* add atomic qualifier, when appearing in parameters *)
@@ -107,7 +108,7 @@ module Make
         env []
 
     let tr_param_ty =
-      if O.kernel then CType.strip_volatile
+      if O.kernel then fun x -> (CType.strip_volatile (CType.strip_const x))
       else Misc.identity
 
      let string_of_params =

--- a/litmus/KSkel.ml
+++ b/litmus/KSkel.ml
@@ -374,6 +374,7 @@ let dump_ctx mts env test =
       O.o "/* Shared locations */" ;
       List.iter
         (fun (s,t) ->
+          let t = CType.strip_const t in
           let t = CType.strip_volatile t in
           if U.is_aligned s env then
             let pp_t = SkelUtil.type_name s in
@@ -628,7 +629,7 @@ let dump_threads _tname env test =
   let global_env = U.select_global env in
   let global_env =
     List.map
-      (fun (x,ty) -> x,CType.strip_volatile ty)
+      (fun (x,ty) -> x,CType.strip_const (CType.strip_volatile ty))
       global_env in
   let aligned_env =
     List.filter

--- a/litmus/skel.ml
+++ b/litmus/skel.ml
@@ -748,7 +748,7 @@ module Make
                 (fun (b,t) k -> match t with
                 | Base "mtx_t" -> k
                 | _ ->
-                    let pp_t = pp_t b (CType.strip_volatile t) in
+                    let pp_t = pp_t b (CType.strip_volatile (CType.strip_const t)) in
                     let a = tag_mem b in
                     begin match t,do_staticalloc with
                     | Array _,false ->
@@ -1133,6 +1133,7 @@ module Make
           List.iter
             (fun (a,t) ->
               let t = CType.strip_volatile t in
+              let t = CType.strip_const t in
               match t with
               | Base "mtx_t" -> ()
               | _ ->

--- a/litmus/skelUtil.ml
+++ b/litmus/skelUtil.ml
@@ -60,7 +60,7 @@ let dump_global_type loc t = match t with
 
 let rec nitems t = match t with
 | Array (_,sz) -> sz
-| Volatile t|Atomic t -> nitems t
+| Volatile t|Atomic t|Const t -> nitems t
 | Base _|Pointer _ -> 1
 
 let dump_fatom_tag d ((p,lbl),v) =
@@ -305,7 +305,7 @@ module Make
             ["("; "oa:%s";  ", af:%d"; ", db:%d";
              ", dbm:%d"; ", valid:%d"; ", el0:%d"; ")"]
         | CType.Base t -> [pp_fmt_base t]
-        | CType.Atomic t|CType.Volatile t -> pp_fmt t
+        | CType.Atomic t|CType.Volatile t|CType.Const t-> pp_fmt t
         | CType.Array (t,sz) ->
             let fmt_elt = pp_fmt_base t in
             let fmts = Misc.replicate sz fmt_elt in


### PR DESCRIPTION
Consider the following fragment of a litmus C test:
```
P0 (const int* y,volatile int* x) {
  int r0 = *x;
  atomic_thread_fence(memory_order_release);
  *y = 1;
}
```
which uses `const` qualified types. This patch adds parsing support for
`const` qualified types. Like `volatile` we do not implement semantics
for `const` in Herd.

Additionally we add testing infrastructure to automatically test litmus
C tests against the `rc11.cat` memory model, like we do with `AArch64`.
As such, unittests are provided for const and volatile qualified types in herd

Following herd#33