### PR TITLE
[lib]: Added void ctype

### DIFF
--- a/lib/CType.ml
+++ b/lib/CType.ml
@@ -26,6 +26,7 @@ type t =
 (** limited arrays *)
   | Array of base * int
 
+let void = Base "void"
 let voidstar = Pointer (Base "void")
 let word = Base "int"
 let quad = Base "int64_t"

--- a/lib/CType.mli
+++ b/lib/CType.mli
@@ -26,6 +26,7 @@ type t =
 (** limited arrays *)
   | Array of base * int
 
+val void : t
 val voidstar : t
 val word : t
 val quad : t


### PR DESCRIPTION
Consider the C code fragment:
```
void *P0 (...) {
    ....
}
```
which is the (pthread friendly) format of concurrent C functions. We may
wish to generate this using diy, and so we would need to know to print a
void pointer type. This patch adds the `void` type in lib, which we can
later combine to generate such a code fragment.