### PR TITLE
[lib] Added addret variant to prepend voidstar type

### DIFF
--- a/gen/CCompile_gen.ml
+++ b/gen/CCompile_gen.ml
@@ -927,6 +927,9 @@ module Make(O:Config) : Builder.S
 
 
       let dump_proc_code chan p (a,i) =
+        let addret = O.variant Variant_gen.AddRet in
+        if addret then
+          fprintf chan "void *";
         fprintf chan "%s (%s) {\n" (pp_proc p) (dump_args a) ;
         dump_ins chan indent1 i ;
         fprintf chan "}\n" ;

--- a/gen/variant_gen.ml
+++ b/gen/variant_gen.ml
@@ -28,6 +28,8 @@ type t =
   | MemTag
 (* C: Prevents the use of Volatile to capture bugs in compilation *)
   | NoVolatile
+(* C: Prepends void * type on thread functions - needed to make compilable C *)
+  | AddRet
 (* Morello C64 instruction set *)
   | Morello
 (* Explicit virtual memory *)
@@ -37,7 +39,7 @@ type t =
 
 let tags =
  ["AsAmo";"ConstsInInit";"Mixed";"FullMixed";"Self"; "MemTag";
-  "NoVolatile"; "Morello"; "kvm"; "Neon"; ]
+  "NoVolatile"; "AddRet"; "Morello"; "kvm"; "Neon"; ]
 
 let parse tag = match Misc.lowercase tag with
 | "asamo" -> Some AsAmo
@@ -47,6 +49,7 @@ let parse tag = match Misc.lowercase tag with
 | "self" -> Some Self
 | "memtag" -> Some MemTag
 | "novolatile" -> Some NoVolatile
+| "addret" -> Some AddRet
 | "morello" -> Some Morello
 | "kvm" -> Some KVM
 | "neon" -> Some Neon
@@ -60,6 +63,7 @@ let pp = function
   | Self -> "Self"
   | MemTag -> "MemTag"
   | NoVolatile -> "NoVolatile"
+  | AddRet -> "AddRet"
   | Morello -> "Morello"
   | KVM -> "kvm"
   | Neon -> "Neon"

--- a/gen/variant_gen.mli
+++ b/gen/variant_gen.mli
@@ -28,6 +28,8 @@ type t =
   | MemTag
 (* C: Prevents the use of Volatile to capture bugs in compilation *)
   | NoVolatile
+(* C: Prepends void * type on thread functions - needed to make compilable C *)
+  | AddRet
 (* Morello C64 instruction set *)
   | Morello
 (* Explicit virtual memory *)


### PR DESCRIPTION
This allows diy to generate valid C++11 code.
The use of voidstar makes the thread functions valid
C++11 so that they can be compiled and used as a concurrent
program.

For instance, running

diy7 -arch C -variant addret

will generate C functions with 'void \*' preprended on front of each:

```
void *P0 ( ... ) { ... }
```