### PR TITLE
Prints void* for C tests - makes valid C

### DIFF
--- a/lib/dumpCAst.ml
+++ b/lib/dumpCAst.ml
@@ -24,7 +24,8 @@ let dump_prog cfun =
           Printf.sprintf "%s %s" (string_of_ty param_ty) param_name
         in
         let params = String.concat ", " (List.map f params) in
-        Printf.sprintf "P%i(%s) {\n%s\n}\n" i params body
+        (* void return type make this valid C, the parser accepts it*)
+        Printf.sprintf "void *P%i(%s) {\n%s\n}\n" i params body
     | CAst.Global x -> Printf.sprintf "{%s}\n\n" x
   in
   [f cfun]


### PR DESCRIPTION
updates the CDumper so it outputs `void *` on thread functions so they are compilable artifacts