### PR TITLE
Add region/scope parsing to C parser, made extra data list

### DIFF
--- a/herd/machModelChecker.ml
+++ b/herd/machModelChecker.ml
@@ -442,7 +442,10 @@ module Make
                 evts
                 (BellModel.get_mem_annots bi) in
             let open MiscParser in
-            begin match test.Test_herd.extra_data with
+            let extra = test.Test_herd.extra_data in
+            begin
+              List.fold_right
+              (fun e m -> match e with
               (* No region in test, empty regions *)
             | NoExtra|BellExtra {BellInfo.regions=None;_} ->
                 I.add_sets m
@@ -481,7 +484,9 @@ module Make
                        end in
                        (tag,set)::k)
                      (BellModel.get_region_sets bi) [])
-            | CExtra _ -> m (* Ignore CExtra ?? *)
+            | CExtra _ -> m (* Ignore CExtra ?? *))
+            extra
+            m
             end in
 (* Scope relations from bell info *)
       let m =
@@ -489,10 +494,16 @@ module Make
         | None -> m
         | Some _ ->
             let open MiscParser in
-            let extract_tbi e = match test.Test_herd.extra_data with
-            | NoExtra|CExtra _ ->
-                None (* must be here as, O.bell_mode_info is *)
-            | BellExtra tbi -> e tbi in
+            let extract_tbi e =
+              let extra = test.Test_herd.extra_data in
+              let scope_opt =
+                List.filter_map
+                  (function
+                   | NoExtra|CExtra _ ->
+                      None (* must be here as, O.bell_mode_info is *)
+                   | BellExtra tbi -> e tbi)
+                  extra in
+                List.nth_opt scope_opt 0 in
             let scopes =  extract_tbi (fun tbi -> tbi.BellInfo.scopes) in
             let m = match scopes with
               (* If no scope definition in test, do not build relations, will fail

--- a/herd/test_herd.ml
+++ b/herd/test_herd.ml
@@ -35,7 +35,7 @@ type
      ffaults: 'fset;
      observed : 'locset ;
      displayed : 'locset ;
-     extra_data : MiscParser.extra_data ;
+     extra_data : MiscParser.extra_data list ;
      access_size : MachSize.sz list ;
      proc_info : proc_info ;
    }
@@ -221,7 +221,7 @@ module Make(A:Arch_herd.S) =
        flocs = [] ; ffaults = A.FaultAtomSet.empty;
        observed = A.RLocSet.empty;
        displayed = A.RLocSet.empty;
-       extra_data = MiscParser.empty_extra;
+       extra_data = [MiscParser.empty_extra];
        access_size = [];
        proc_info = [];
      }

--- a/herd/test_herd.mli
+++ b/herd/test_herd.mli
@@ -35,7 +35,7 @@ type
      ffaults : 'fset;
      observed : 'locset ;
      displayed : 'locset ;
-     extra_data : MiscParser.extra_data ;
+     extra_data : MiscParser.extra_data list;
      access_size : MachSize.sz list ;
      proc_info : proc_info ;
    }

--- a/jingle/cDumper.ml
+++ b/jingle/cDumper.ml
@@ -179,10 +179,13 @@ let do_dump withinfo chan doc t =
     DumpUtils.dump_locations
       dump_location ParsedConstant.pp_v t.MiscParser.locations in
   if locs <> "" then fprintf chan "%s\n" locs ;
-  begin match t.MiscParser.extra_data with
-	| MiscParser.NoExtra|MiscParser.CExtra _ -> ()
-	| MiscParser.BellExtra bi ->
-           fprintf chan "\n%s\n" (BellInfo.pp bi)
+  let extra = t.MiscParser.extra_data in
+  begin List.iter
+    (function
+	 | MiscParser.NoExtra|MiscParser.CExtra _ -> ()
+	 | MiscParser.BellExtra bi ->
+         fprintf chan "\n%s\n" (BellInfo.pp bi))
+    extra
   end ;
   fprintf chan "%s\n" (dump_constr t.MiscParser.condition) ;
   ()

--- a/lib/BellCheck.ml
+++ b/lib/BellCheck.ml
@@ -245,10 +245,13 @@ module Make
             code)
         parsed.MiscParser.prog in
       let parsed = { parsed with MiscParser.prog; } in
-      let test_bi = parsed.MiscParser.extra_data in
-      let test_bi = match test_bi with
-      | MiscParser.BellExtra b -> b
-      | _ -> Warn.fatal "Error getting bell information from test" in
+      let test_bi =
+        let test_bi = parsed.MiscParser.extra_data in
+        List.hd (List.map
+          (function
+           | MiscParser.BellExtra b -> b
+           | _ -> Warn.fatal "Error getting bell information from test")
+          test_bi) in
       begin match test_bi.BellInfo.regions with
       | Some r -> check_regions r bi
       | _ -> ()
@@ -256,7 +259,7 @@ module Make
       let st = Misc.app_opt (fun st -> check_scopes st bi)  test_bi.BellInfo.scopes in
       let test_bi = { test_bi with BellInfo.scopes=st;} in
       let () = Misc.check_opt (fun lvls -> check_levels lvls bi)  test_bi.BellInfo.levels in
-      { parsed with MiscParser.extra_data = MiscParser.BellExtra test_bi; }
+      { parsed with MiscParser.extra_data = [MiscParser.BellExtra test_bi;] }
 
     let check = match C.info with
     | None -> Misc.identity

--- a/lib/CLexer.mll
+++ b/lib/CLexer.mll
@@ -25,6 +25,7 @@ module LU = LexUtils.Make(O)
 let tr_name s = match s with
 | "volatile" -> VOLATILE
 | "_Atomic" -> ATOMIC
+| "atomic" -> ATOMIC_BASE
 | "char" -> CHAR
 | "int" -> INT
 | "long" -> LONG
@@ -135,6 +136,7 @@ rule token deep = parse
 | "constvar:" (name as s) { CONSTVAR s }
 | "codevar:" (name as s) { CODEVAR s }
 | '%' name as s { IDENTIFIER s }
+| "regions" { REGIONS }
 | name as x   { tr_name x  }
 | eof { EOF }
 | "" { LexMisc.error "C lexer" lexbuf }

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,6 @@
 
 
 (menhir (modules PPCParser) (flags  --fixed-exception))
-(menhir (modules CParser) (flags  --fixed-exception))
 (menhir (modules ARMParser) (flags  --fixed-exception))
 (menhir (modules MIPSParser) (flags  --fixed-exception))
 (menhir (modules X86Parser) (flags  --fixed-exception))
@@ -23,6 +22,10 @@
 (menhir (modules scopeRules scopeParser)
   (merge_into scopeParser)
    (flags  --fixed-exception))
+
+(menhir (modules scopeRules BellExtraRules CParser)
+  (merge_into CParser)
+  (flags  --fixed-exception))
 
 (library
  (name herdtools)

--- a/lib/genParser.ml
+++ b/lib/genParser.ml
@@ -173,7 +173,7 @@ module Make
          filter = filter;
          condition = final;
          locations = locs;
-         extra_data ;
+         extra_data = [extra_data] ;
        } in
       let name  = name.Name.name in
       let parsed =

--- a/lib/miscParser.ml
+++ b/lib/miscParser.ml
@@ -178,7 +178,7 @@ type ('i, 'p, 'prop, 'loc, 'v) result =
       filter : 'prop option ;
       condition : 'prop ConstrGen.constr ;
       locations : ('loc,'v) LocationsItem.t list ;
-      extra_data : extra_data ;
+      extra_data : extra_data list ;
 }
 
 (* Easier to handle *)

--- a/lib/miscParser.mli
+++ b/lib/miscParser.mli
@@ -83,7 +83,7 @@ type ('i, 'p, 'prop, 'loc, 'v) result =
       filter : 'prop option ;
       condition : 'prop ConstrGen.constr ;
       locations : ('loc,'v) LocationsItem.t list ;
-      extra_data : extra_data ;
+      extra_data : extra_data list;
     }
 
 (* Easier to handle *)

--- a/lib/simpleDumper.ml
+++ b/lib/simpleDumper.ml
@@ -107,11 +107,13 @@ end = struct
     | None -> ()
     | Some p -> Out.fprintf chan "filter %s\n" (I.dump_prop p)
     end ;
-    begin match t.extra_data with
-    | NoExtra|CExtra _ -> ()
-    | BellExtra bi ->
+    let print_extra t =
+      begin match t with
+        | NoExtra|CExtra _ -> ()
+        | BellExtra bi     ->
         Out.fprintf chan "\n%s\n" (BellInfo.pp bi)
-    end ;
+      end in
+    let _ = List.map print_extra t.extra_data in
     Out.fprintf chan "%s\n" (I.dump_constr t.condition) ;
     ()
 

--- a/litmus/CGenParser_litmus.ml
+++ b/litmus/CGenParser_litmus.ml
@@ -156,7 +156,7 @@ let check_regs = GenParserUtils.check_regs
          filter = filter;
          condition = final;
          locations = locs;
-         extra_data = MiscParser.empty_extra;
+         extra_data = [MiscParser.empty_extra];
        } in
       let name  = name.Name.name in
       let parsed =

--- a/litmus/compile.ml
+++ b/litmus/compile.ml
@@ -709,8 +709,8 @@ type P.code = MiscParser.proc * A.pseudo list)
       let bellinfo =
         let open MiscParser in
         match extra_data with
-        | NoExtra|CExtra _ -> None
-        | BellExtra i -> Some i in
+        | [BellExtra i] -> Some i
+        | _ -> None in
       let code_typed = type_outs ty_env1 code in
       let flocs,ffaults = LocationsItem.locs_and_faults locs in
         { T.init = initenv ;

--- a/litmus/top_klitmus.ml
+++ b/litmus/top_klitmus.ml
@@ -196,7 +196,7 @@ module Top(O:Config)(Tar:Tar.S) = struct
       type token = CParser.token
       module CL = CLexer.Make(struct let debug = false end)
       let lexer = CL.token false
-      let parser = CParser.shallow_main
+      let parser x y = fst (CParser.shallow_main x y)
     end
     module Pseudo =
       struct

--- a/litmus/top_litmus.ml
+++ b/litmus/top_litmus.ml
@@ -342,7 +342,7 @@ end = struct
         type token = CParser.token
         module CL = CLexer.Make(struct let debug = false end)
         let lexer = CL.token false
-        let parser = CParser.shallow_main
+        let parser x y= fst (CParser.shallow_main x y)
       end
 
       module A' = CArch_litmus.Make(O)

--- a/tools/CDumper.ml
+++ b/tools/CDumper.ml
@@ -71,7 +71,7 @@ end = struct
           Out.fprintf chan "%s=%s\n" k i)
       t.info ;
     Out.fprintf chan "\n{%s}\n\n" (dump_state  t.init) ;
-    begin match t.extra_data with
+    let print chan extra = begin match extra with
     | CExtra pss ->
         List.iter2
           (fun ((i,_),code) ps ->
@@ -86,8 +86,11 @@ end = struct
             Out.fprintf chan "}\n")
           t.prog pss
     | _ -> ()
-    end ;
-    let locs = DumpUtils.dump_locations dump_loc ParsedConstant.pp_v t.locations in
+    end in
+    let extras = t.extra_data in
+    List.iter (print chan) extras;
+    let locs =
+      DumpUtils.dump_locations dump_loc ParsedConstant.pp_v t.locations in
     if locs <> "" then Out.fprintf chan "%s\n" locs ;
     begin match t.filter with
     | None -> ()

--- a/tools/mlisa2c.ml
+++ b/tools/mlisa2c.ml
@@ -188,7 +188,8 @@ module Top(O:Config)(Out:OutTests.S) = struct
 
 
   let do_tr p =
-    { p with prog = tr_prog p.prog; extra_data=CExtra (tr_extra p.prog);}
+    { p with prog = tr_prog p.prog;
+      extra_data=[CExtra (tr_extra p.prog)]; }
 
   let tr_test idx_out name parsed =
     let fname = name.Name.file in

--- a/tools/transposeDumper.ml
+++ b/tools/transposeDumper.ml
@@ -103,11 +103,16 @@ end = struct
         List.iter (fun i -> fprintf chan "%s\n" (fmt_io i)) code ;
         ())
       prog ;
-    begin match t.extra_data with
-    | NoExtra|CExtra _ -> ()
-    | BellExtra bi ->
-        dump_sep chan "Scope" ;
-        fprintf chan "%s" (BellInfo.pp bi)
+    let extra = t.extra_data in
+    begin
+      List.iter
+        (function
+         | NoExtra|CExtra _ -> ()
+         | BellExtra bi ->
+           dump_sep chan "Scope" ;
+           fprintf chan "%s" (BellInfo.pp bi))
+        extra;
+      ()
     end ;
     (* Conditions *)
     dump_sep chan "Check" ;


### PR DESCRIPTION
This patch allows us to add region and scope information to C tests.
This also changes the extra_data parameter to store a list of data
so we can pass multiple things into the test.