### PR TITLE
[herd]: Print Timeout for test with -debug timeout

### DIFF
--- a/herd/debug_herd.ml
+++ b/herd/debug_herd.ml
@@ -28,6 +28,7 @@ type t = {
     pretty : bool ;
     mixed : bool ;
     files : bool ;
+    timeout : bool ;
   }
 
 let tags =
@@ -43,6 +44,7 @@ let tags =
   "pretty";
   "mixed";
   "files";
+  "timeout"
 ]
 
 let none =
@@ -58,6 +60,7 @@ let none =
    pretty = false ;
    mixed = false ;
    files = false ;
+   timeout = false ;
  }
 
 let parse t tag = match tag with
@@ -72,4 +75,5 @@ let parse t tag = match tag with
   | "pretty" -> Some { t with pretty = true ;}
   | "mixed" -> Some { t with mixed = true ;}
   | "files"|"file" -> Some { t with files = true ;}
+  | "timeout" -> Some { t with timeout = true ;}
   | _ -> None

--- a/herd/debug_herd.mli
+++ b/herd/debug_herd.mli
@@ -28,6 +28,7 @@ type t = {
   pretty : bool ;
   mixed : bool ;
   files : bool ;
+  timeout : bool ;
   }
 
 val none : t

--- a/herd/herd.ml
+++ b/herd/herd.ml
@@ -671,7 +671,10 @@ let () =
 
 (* If interval timer enabled and triggered,
    then stop test with not output at all *)
-    Itimer.set_signal Config.timeout (fun _ -> raise Misc.Timeout) ;
+    Itimer.set_signal
+      Config.timeout
+      (fun _ -> raise Misc.Timeout)
+      !debug.Debug_herd.timeout;
     Misc.fold_argv_or_stdin
       (fun name seen ->
         try from_file name seen

--- a/herd/itimer.ml
+++ b/herd/itimer.ml
@@ -20,7 +20,7 @@ let dbg = false
 
 let name = ref ""
 
-let set_signal timeout f =
+let set_signal timeout f dbg =
   match timeout with
   | None -> ()
   | Some _ ->

--- a/herd/itimer.mli
+++ b/herd/itimer.mli
@@ -18,8 +18,9 @@
 
 
 (** [set_signal timeout handle] set signal handle for timer.
-  * Argument timeout is an option, if [None] do nothing. *)
-val set_signal : float option -> (int -> unit) -> unit
+  * Argument timeout is an option, if [None] do nothing
+  * Argument debug is default false, if [true] print timeout debug *)
+val set_signal : float option -> (int -> unit) -> bool -> unit
 
 (** [start timeout] start interval for the given period.
   * Argument timeout is an option, if [None] do nothing,


### PR DESCRIPTION
Suppose you run `herd7 -timeout 5.0 expensive_test.litmus` and it times
out on `expensive_test`. Herd silently finishes with `expensive_test` timing out and it is
desirable to be able to have a list of timed-out tests in automated
testing. This patch prints a timeout message to standard error so we can
collect lists of tests which did not finish:

```
> herd7 -timeout 5.0 -debug timeout expensive_test.litmus
...
Timeout for expensive_test.litmus
```